### PR TITLE
fix: improve view counting — remove example exclusion, add IP dedup

### DIFF
--- a/app/[owner]/[repo]/page.tsx
+++ b/app/[owner]/[repo]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
+import { headers } from "next/headers";
 import { ReversePromptHome } from "@/components/reverse-prompt-home";
-import { isHomeExampleRepo } from "@/lib/home-example-repos";
 import { isValidGitHubRepoPath, normalizeRepoSegment } from "@/lib/parse-github-repo";
 import { getSupabase } from "@/lib/supabase";
 
@@ -26,14 +26,18 @@ export default async function RepoPage({ params }: PageProps) {
   try {
     const supabase = getSupabase();
     if (supabase) {
-      if (!isHomeExampleRepo(owner, repoNorm)) {
-        const { error: viewsError } = await supabase.rpc("increment_views", {
-          p_owner: owner,
-          p_repo: repoNorm,
-        });
-        if (viewsError) {
-          console.warn("[repo-page] increment_views:", viewsError.message);
-        }
+      const hdrs = await headers();
+      const ip =
+        hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+        hdrs.get("x-real-ip") ??
+        "unknown";
+      const { error: viewsError } = await supabase.rpc("increment_views", {
+        p_owner: owner,
+        p_repo: repoNorm,
+        p_ip: ip,
+      });
+      if (viewsError) {
+        console.warn("[repo-page] increment_views:", viewsError.message);
       }
       const { data } = await supabase
         .from("prompt_cache")


### PR DESCRIPTION
## What Changed

Two improvements to view counting:

1. **Removed `isHomeExampleRepo` exclusion** — all repositories now count views, including home page examples (Next.js, React, etc.)
2. **Added IP-based deduplication** — views are counted once per IP per repo per 24-hour window, preventing refresh abuse

### Modified files
- `app/[owner]/[repo]/page.tsx` — removed `isHomeExampleRepo` check, added IP extraction via `headers()`, passing `p_ip` to `increment_views`

## Why This Change

**Example exclusion:** Home page example repos (Next.js, React, Openclaw, Supabase, Linux) always showed 0 views in the library. The example buttons on the home page don't trigger server-side navigation anyway — they only set the input field — so the exclusion was unnecessary and misleading.

**Deduplication:** Without it, a single user refreshing a page inflates views indefinitely. The 24h IP window is simple, effective, and requires no client-side fingerprinting.

## Setup required

Replace the existing `increment_views` function and add a `view_log` table:

```sql
CREATE TABLE IF NOT EXISTS view_log (
  id serial PRIMARY KEY,
  owner text NOT NULL,
  repo text NOT NULL,
  ip text NOT NULL,
  viewed_at timestamptz DEFAULT now()
);

CREATE INDEX IF NOT EXISTS idx_view_log_dedup
  ON view_log(owner, repo, ip, viewed_at);

CREATE OR REPLACE FUNCTION increment_views(p_owner text, p_repo text, p_ip text DEFAULT 'unknown')
RETURNS void AS $$
BEGIN
  -- Skip if this IP already viewed this repo in the last 24 hours
  IF EXISTS (
    SELECT 1 FROM view_log
    WHERE owner = p_owner AND repo = p_repo AND ip = p_ip
      AND viewed_at > now() - interval '24 hours'
  ) THEN
    RETURN;
  END IF;

  -- Log the view
  INSERT INTO view_log (owner, repo, ip) VALUES (p_owner, p_repo, p_ip);

  -- Increment the counter
  UPDATE prompt_cache SET views = views + 1
  WHERE owner = p_owner AND repo = p_repo;
END;
$$ LANGUAGE plpgsql;
```

**Backwards compatible:** The `p_ip` parameter defaults to `'unknown'`, so any existing callers without the IP argument will still work (views just won't deduplicate for them).

## Testing Done
- [x] Views increment for example repos on direct URL visit
- [x] Views increment for non-example repos (unchanged)
- [x] Duplicate views from same IP within 24h are ignored
- [x] TypeScript — no errors
- [x] ESLint — no errors

## Type of Change
- [x] `fix:` Bug fix