### PR TITLE
fix(views): server-side IP hash dedup, remove localStorage gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ OPENROUTER_API_KEY=
 
 # Cache TTL for reverse-prompt results in Supabase (hours; default 24)
 # CACHE_TTL_HOURS=24
+
+# Optional secret salt for hashing visitor IPs in the view counter.
+# Generate one with: openssl rand -hex 32
+# If unset, a public fallback is used and a warning is logged in production.
+# VIEWS_IP_SALT=

--- a/app/api/increment-views/route.ts
+++ b/app/api/increment-views/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { isHomeExampleRepo } from "@/lib/home-example-repos";
 import {
@@ -7,6 +8,56 @@ import {
 import { getSupabase } from "@/lib/supabase";
 
 export const runtime = "nodejs";
+
+/* Salt for IP hashing. The default below provides only token protection since
+   it lives in the public source tree — anyone can recompute hashes for the
+   IPv4 space. Set VIEWS_IP_SALT in the deployment environment to a long random
+   secret for meaningful protection of stored hashes. */
+const DEFAULT_IP_HASH_SALT = "gitreverse-views-v1";
+const IP_HASH_SALT =
+  process.env.VIEWS_IP_SALT?.trim() || DEFAULT_IP_HASH_SALT;
+
+if (
+  IP_HASH_SALT === DEFAULT_IP_HASH_SALT &&
+  process.env.NODE_ENV === "production"
+) {
+  console.warn(
+    "[increment-views] VIEWS_IP_SALT is not set — falling back to the public default. " +
+      "Set a random secret in your deployment env for production use."
+  );
+}
+
+/** Derive a stable, privacy-preserving hash of the visitor IP.
+ *
+ *  Header trust order:
+ *  1. `x-real-ip` — set by Vercel (and most reverse proxies) directly from
+ *     the connecting socket, so it cannot be spoofed by the client.
+ *  2. `x-forwarded-for` — first non-empty entry. Less trustworthy (the client
+ *     can prepend arbitrary values), but better than nothing for non-Vercel
+ *     deployments. We skip empty entries to avoid the `,real-ip` empty-prefix
+ *     bypass where `split(",")[0]` would otherwise return "".
+ */
+function hashVisitorIp(req: NextRequest): string | null {
+  const realIp = req.headers.get("x-real-ip")?.trim();
+  if (realIp) {
+    return createHash("sha256")
+      .update(`${IP_HASH_SALT}:${realIp}`)
+      .digest("hex");
+  }
+
+  const xffFirst = req.headers
+    .get("x-forwarded-for")
+    ?.split(",")
+    .map((s) => s.trim())
+    .find((s) => s.length > 0);
+  if (xffFirst) {
+    return createHash("sha256")
+      .update(`${IP_HASH_SALT}:${xffFirst}`)
+      .digest("hex");
+  }
+
+  return null;
+}
 
 export async function POST(req: NextRequest) {
   let body: unknown;
@@ -53,9 +104,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Database unavailable." }, { status: 503 });
   }
 
+  const ipHash = hashVisitorIp(req);
+
   const { error } = await supabase.rpc("increment_views", {
     p_owner: owner,
     p_repo: repo,
+    p_ip_hash: ipHash,
   });
   if (error) {
     console.warn("[increment-views]", error.message);

--- a/components/reverse-prompt-home.tsx
+++ b/components/reverse-prompt-home.tsx
@@ -109,26 +109,14 @@ export function ReversePromptHome({
     if (!o || !r) return;
     if (isHomeExampleRepo(o, r)) return;
 
-    const key = `viewed__${o}__${r}`;
-    const existing = localStorage.getItem(key);
-    if (existing === "1" || existing === "pending") return;
-
-    localStorage.setItem(key, "pending");
+    /* Server-side dedupes by IP hash, so we no longer need a localStorage gate. */
     void fetch("/api/increment-views", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ owner: o, repo: r }),
-    })
-      .then((res) => {
-        if (!res.ok) {
-          localStorage.removeItem(key);
-          return;
-        }
-        localStorage.setItem(key, "1");
-      })
-      .catch(() => {
-        localStorage.removeItem(key);
-      });
+    }).catch(() => {
+      /* swallow — view counter is best-effort */
+    });
   }, [owner, repo]);
 
   useEffect(() => {


### PR DESCRIPTION
## What this PR does

Implements **one view per IP** at the database layer, as requested.

1. **`app/api/increment-views/route.ts`** — extract visitor IP from `x-real-ip` (preferred) or `x-forwarded-for`, SHA-256 hash it (salt configurable via env), and pass `p_ip_hash` to the `increment_views` RPC.
2. **`components/reverse-prompt-home.tsx`** — drop the client-side `viewed__owner__repo` localStorage gate. It cluttered browser storage indefinitely (one key per repo viewed, forever) and is now redundant with server-side dedup.
3. **`.env.example`** — document the new optional `VIEWS_IP_SALT` variable.

## Why hash the IP

Storing raw IPs in the database is a privacy concern (PII under GDPR). Hashing means:
- Same visitor → same hash → dedup works
- Database leak does not expose visitor IPs

### About the salt — fully transparent

The IP hash uses a salt sourced from `process.env.VIEWS_IP_SALT`, falling back to a public constant (`gitreverse-views-v1`) when unset.

**Be aware:** the public fallback offers only _token_ protection. Anyone with access to the source can recompute the hash for the entire IPv4 space, so a leaked DB dump combined with public source gives back the visitor IPs. The fallback exists so the feature works out of the box in dev and for deployers who don't read setup docs.

**For real protection in production**, set `VIEWS_IP_SALT` to a long random secret in your hosting environment (Vercel, Railway, etc.):

```bash
openssl rand -hex 32
```

When unset, the API logs a one-time warning at module load in production so it's hard to miss:

```
[increment-views] VIEWS_IP_SALT is not set — falling back to the public default.
Set a random secret in your deployment env for production use.
```

This is **fully optional** — no setup required for the PR to work, but recommended for production.

## Header trust order — preventing client spoofing

A naive `x-forwarded-for: split(",")[0]` implementation would be vulnerable to two client-controlled attacks:

1. **Empty-prefix bypass** — sending `x-forwarded-for: ,8.8.8.8` makes Vercel append the real client IP, producing `,8.8.8.8, real-ip`. `split(",")[0]` then returns `""`, the function returns `null`, and the SQL fallback bumps views without dedup. An attacker rotates this to inflate views indefinitely.
2. **First-entry spoofing** — sending `x-forwarded-for: 1.2.3.4` puts an attacker-controlled value at index 0 of the chain. Each rotation produces a unique hash, defeating dedup entirely.

This PR uses a stricter trust order:

1. **`x-real-ip` first** — Vercel (and most reverse proxies) set this directly from the connecting socket, ignoring whatever the client sent. Cannot be spoofed.
2. **`x-forwarded-for` fallback** — for non-Vercel hosts that don't set `x-real-ip`. We take the *first non-empty* entry (skipping empty strings), which closes the empty-prefix bypass. First-entry spoofing remains theoretically possible without a trusted proxy, which is an inherent limitation of `x-forwarded-for` parsing — deployers running behind a non-Vercel proxy should configure it to overwrite or strip client-supplied XFF values.

## Required SQL migration

Run this once in Supabase **before** deploying:

```sql
-- New table: one row per (owner, repo, ip_hash) — permanent dedup, no time window.
CREATE TABLE IF NOT EXISTS view_log (
  owner      text NOT NULL,
  repo       text NOT NULL,
  ip_hash    text NOT NULL,
  viewed_at  timestamptz NOT NULL DEFAULT now(),
  PRIMARY KEY (owner, repo, ip_hash)
);

-- Replace the existing 2-arg increment_views with a 3-arg version.
-- p_ip_hash is nullable for backwards-compat: if NULL/empty, the counter
-- still bumps but no dedup is performed.
DROP FUNCTION IF EXISTS increment_views(text, text);

CREATE FUNCTION increment_views(
  p_owner   text,
  p_repo    text,
  p_ip_hash text DEFAULT NULL
) RETURNS void AS $$
BEGIN
  IF p_ip_hash IS NULL OR p_ip_hash = '' THEN
    UPDATE prompt_cache
       SET views = views + 1
     WHERE owner = p_owner AND repo = p_repo;
    RETURN;
  END IF;

  INSERT INTO view_log (owner, repo, ip_hash)
       VALUES (p_owner, p_repo, p_ip_hash)
  ON CONFLICT (owner, repo, ip_hash) DO NOTHING;

  -- Only bump the counter when INSERT actually added a row (i.e. first view from this IP).
  IF FOUND THEN
    UPDATE prompt_cache
       SET views = views + 1
     WHERE owner = p_owner AND repo = p_repo;
  END IF;
END;
$$ LANGUAGE plpgsql;
```

## What this PR does NOT touch (intentionally)

- ❌ `isHomeExampleRepo` exclusion — still in place, home-example repos remain excluded as before
- ❌ History / localStorage logic for `gitreverse_history`
- ❌ Any other view-related behavior

Scope is deliberately tight: only the IP-dedup change you asked for, plus removal of the now-redundant client gate.

## Testing done

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on modified files — clean
- [x] Manual test: same IP visiting twice does not bump views; different IPs do
- [x] Empty-prefix bypass (`x-forwarded-for: ,1.1.1.1`) — no longer returns null
- [x] `VIEWS_IP_SALT` set and unset — both work, warning fires when unset in production

## Supersedes

Closes #28 (which had stale architecture targeting `app/[owner]/[repo]/page.tsx` before the views logic moved to the API route).