### PR TITLE
Fix manual control panel when opening focus links from history

### DIFF
--- a/components/reverse-prompt-home.tsx
+++ b/components/reverse-prompt-home.tsx
@@ -115,6 +115,22 @@ export function ReversePromptHome({
   const resultsRef = useRef<HTMLDivElement | null>(null);
   const autoSubmitStartedRef = useRef(false);
 
+  /** Open Manual control and fill the focus when the URL (or SSR) carries a manual focus segment. */
+  useEffect(() => {
+    if (autoSubmitDeep) {
+      setCustomReverse(false);
+      return;
+    }
+    const focus =
+      (autoSubmitFocus?.trim() || initialManualFocus?.trim()) ?? "";
+    if (focus) {
+      setCustomReverse(true);
+      setCustomPrompt(focus);
+    } else {
+      setCustomReverse(false);
+    }
+  }, [autoSubmitDeep, autoSubmitFocus, initialManualFocus]);
+
   const runReversePrompt = useCallback(async (input: string) => {
     setError(null);
     setRateLimited(false);

--- a/components/reverse-prompt-home.tsx
+++ b/components/reverse-prompt-home.tsx
@@ -686,7 +686,7 @@ export function ReversePromptHome({
                         name="customPrompt"
                         rows={4}
                         className="relative z-10 w-full resize-y rounded border-[3px] border-zinc-900 bg-white px-4 py-3 text-base text-zinc-900 placeholder-zinc-500 focus:outline-none disabled:cursor-not-allowed disabled:bg-zinc-100 disabled:opacity-80"
-                        placeholder="ask for detailed prompt or focus on a specific feature"
+                        placeholder="repurpose into your own version, or focus on a specific feature"
                         value={customPrompt}
                         onChange={(e) => setCustomPrompt(e.target.value)}
                         required={customReverse}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Opening a manual-control URL (for example from History, which links to `/:owner/:repo/:focus`) showed only the "Manual control" checkbox. The textarea stayed collapsed and empty, even though the server already knew the focus string (`initialManualFocus` / `autoSubmitFocus`).

## Solution

In `ReversePromptHome`, a small `useEffect` syncs `customReverse` and `customPrompt` from `autoSubmitFocus` and `initialManualFocus`. When either carries a non-empty focus, the panel opens and the prompt field is filled. Deep URLs (`autoSubmitDeep`) turn manual mode off so the deep flow is not mixed with manual UI.

## Verification

- `npm run build` passes.
- `npx eslint components/reverse-prompt-home.tsx` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fce355cd-88a2-4f8f-95d9-7dbcd1e67b80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fce355cd-88a2-4f8f-95d9-7dbcd1e67b80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

