### PR TITLE
Update Discord invite link

### DIFF
--- a/components/library-page.tsx
+++ b/components/library-page.tsx
@@ -305,7 +305,7 @@ export function LibraryPage({ initialData, initialTotal }: LibraryPageProps) {
       <footer className="border-t border-zinc-200 py-6 text-center text-sm text-zinc-500">
         <div className="mx-auto flex max-w-4xl justify-center px-4 sm:px-6">
           <a
-            href="https://discord.gg/Uq7fTGsQX"
+            href="https://discord.gg/bhEMbZMHS"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 font-medium text-zinc-700 underline decoration-zinc-400 underline-offset-2 transition-colors hover:text-zinc-900"

--- a/components/reverse-prompt-home.tsx
+++ b/components/reverse-prompt-home.tsx
@@ -1354,7 +1354,7 @@ export function ReversePromptHome({
             ·
           </span>
           <a
-            href="https://discord.gg/Uq7fTGsQX"
+            href="https://discord.gg/bhEMbZMHS"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 font-medium text-zinc-700 underline decoration-zinc-400 underline-offset-2 transition-colors hover:text-zinc-900"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the stale Discord invite URL in the home footer and library footer

## Testing
- clicked the footer Discord link from `/library` and from `/`, confirming both open the GitReverse Discord invite page
- verified the rendered HTML for both routes contains `https://discord.gg/bhEMbZMHS`
- ran `npm run lint` and confirmed the remaining failures are pre-existing hook-rule issues unrelated to this link update

## Walkthrough
[discord_invite_link_opens_correct_url.mp4](https://cursor.com/agents/bc-266f6e25-125e-43d1-ab97-df45a46f2e08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscord_invite_link_opens_correct_url.mp4)
[Library footer link target](https://cursor.com/agents/bc-266f6e25-125e-43d1-ab97-df45a46f2e08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscord_library_link_target.webp)
[Home footer link target](https://cursor.com/agents/bc-266f6e25-125e-43d1-ab97-df45a46f2e08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscord_home_link_target.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-266f6e25-125e-43d1-ab97-df45a46f2e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-266f6e25-125e-43d1-ab97-df45a46f2e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

