### PR TITLE
Fix localhost link and Vercel security loop regressions

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -15,7 +15,7 @@ import {
   getSupabaseAuthClient,
   isSupabaseAuthConfigured,
 } from "@/lib/supabase-auth";
-import { appHref } from "@/lib/site-url";
+import { getApexHost } from "@/lib/site-url";
 
 export type AuthContextValue = {
   user: User | null;
@@ -71,7 +71,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       throw new Error("GitReverse auth is not configured.");
     }
 
-    const redirectTo = appHref(window.location.host, "/auth/callback");
+    const apexHost = getApexHost(window.location.host);
+    const apexScheme = apexHost.startsWith("localhost") ? "http" : "https";
+    const redirectTo = `${apexScheme}://${apexHost}/auth/callback`;
 
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: "github",

--- a/lib/site-url.ts
+++ b/lib/site-url.ts
@@ -35,17 +35,15 @@ export function getApexHost(host: string): string {
   }
 }
 
-/** Absolute URL on the main GitReverse site. */
-export function mainSiteHref(path: string): string {
-  return `${getSiteBaseUrl()}${normalizePath(path)}`;
-}
-
 /**
  * App navigation href: relative on the apex domain, absolute on website-reverse subdomains.
+ * Derives the apex URL from the hostname itself — no env vars needed.
  */
 export function appHref(host: string, path: string): string {
-  if (parseWebsiteReverseHost(host)) {
-    return mainSiteHref(path);
+  if (!parseWebsiteReverseHost(host)) {
+    return normalizePath(path);
   }
-  return normalizePath(path);
+  const apexHost = getApexHost(host);
+  const scheme = apexHost.startsWith("localhost") ? "http" : "https";
+  return `${scheme}://${apexHost}${normalizePath(path)}`;
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { parseWebsiteReverseHost } from "@/lib/parse-website-reverse-host";
-import { getApexHost } from "@/lib/site-url";
 
 export function proxy(request: NextRequest) {
   const host = request.headers.get("host") ?? "";
@@ -21,13 +20,6 @@ export function proxy(request: NextRequest) {
 
   const parsed = parseWebsiteReverseHost(host);
   if (!parsed) return NextResponse.next();
-
-  // Non-root paths on a website-reverse subdomain belong on the apex app.
-  if (request.nextUrl.pathname !== "/") {
-    const apexUrl = request.nextUrl.clone();
-    apexUrl.host = getApexHost(host);
-    return NextResponse.redirect(apexUrl, 307);
-  }
 
   const url = request.nextUrl.clone();
   url.pathname = `/website/${encodeURIComponent(parsed.slug)}`;


### PR DESCRIPTION
Two regressions from the subdomain nav fix:

- Logo and nav links were resolving to localhost:3000 in production because appHref called getSiteBaseUrl() which falls back to localhost when NEXT_PUBLIC_SITE_URL is unset. Fixed by deriving the apex URL directly from the hostname (discord.gitreverse.com -> gitreverse.com) with no env var needed.
- Vercel bot-protection challenge was firing on every subdomain arrival because the proxy was redirecting all non-root subdomain paths to apex. Removed that redirect entirely — nav links are absolute now so it is not needed.
- Also fixed AuthContext OAuth callback to always use an absolute apex URL.

Made with [Cursor](https://cursor.com)