### PR TITLE
Fix library page load timeouts

### DIFF
--- a/app/api/library/route.ts
+++ b/app/api/library/route.ts
@@ -34,11 +34,23 @@ export async function GET(req: NextRequest) {
         limit,
         useHybrid: hasEmbeddingProvider(),
       });
-      return NextResponse.json(result);
+      return NextResponse.json(result, {
+        headers: {
+          "Cache-Control": "private, no-store",
+        },
+      });
     }
 
     const result = await browseLibrary({ supabase, sort, page, limit });
-    return NextResponse.json({ ...result, strategy: "browse" as const });
+    return NextResponse.json(
+      { ...result, strategy: "browse" as const },
+      {
+        headers: {
+          // Browse is cacheable; keep CDN warm so Library navigations stay fast.
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+        },
+      }
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Search failed.";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
-import { connection } from "next/server";
+import { unstable_cache } from "next/cache";
 import { fetchInitialLibrary } from "@/lib/library-query";
 import { getSupabase } from "@/lib/supabase";
 import { LibraryPage } from "@/components/library-page";
 import { JsonLd } from "@/components/json-ld";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 60;
 
 export const metadata: Metadata = {
   title: "Prompt Library",
@@ -28,18 +28,27 @@ export const metadata: Metadata = {
 
 const INITIAL_LIMIT = 24;
 
+const getCachedInitialLibrary = unstable_cache(
+  async () => {
+    const supabase = getSupabase();
+    if (!supabase) return { data: [], total: 0 };
+    try {
+      return await fetchInitialLibrary(supabase, INITIAL_LIMIT);
+    } catch (error) {
+      console.error(
+        "[library] initial fetch failed:",
+        error instanceof Error ? error.message : error
+      );
+      return { data: [], total: 0 };
+    }
+  },
+  ["library-initial-newest-v2"],
+  { revalidate: 60 }
+);
+
 export default async function LibraryRoute() {
-  await connection();
-  const supabase = getSupabase();
-
-  let initialData: Awaited<ReturnType<typeof fetchInitialLibrary>>["data"] = [];
-  let initialTotal = 0;
-
-  if (supabase) {
-    const result = await fetchInitialLibrary(supabase, INITIAL_LIMIT);
-    initialData = result.data;
-    initialTotal = result.total;
-  }
+  const { data: initialData, total: initialTotal } =
+    await getCachedInitialLibrary();
 
   const collectionJsonLd = {
     "@context": "https://schema.org",

--- a/components/library-page.tsx
+++ b/components/library-page.tsx
@@ -43,7 +43,6 @@ export function LibraryPage({ initialData, initialTotal }: LibraryPageProps) {
   const [page, setPage] = useState(0);
   const [isPending, startTransition] = useTransition();
   const [loadingMore, setLoadingMore] = useState(false);
-  const [initialFetchDone, setInitialFetchDone] = useState(initialData.length > 0);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isFirstRender = useRef(true);
 
@@ -61,7 +60,8 @@ export function LibraryPage({ initialData, initialTotal }: LibraryPageProps) {
         limit: String(PAGE_SIZE),
       });
       const res = await fetch(`/api/library?${params.toString()}`, {
-        cache: "no-store",
+        // Browse responses are CDN-cached; search stays private/no-store server-side.
+        cache: searchVal ? "no-store" : "default",
       });
       if (!res.ok) return;
       const json = (await res.json()) as {
@@ -95,15 +95,6 @@ export function LibraryPage({ initialData, initialTotal }: LibraryPageProps) {
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
     };
   }, [search, sort, fetchPage]);
-
-  // Re-sync after mount so library data is not stale from RSC/router cache.
-  useEffect(() => {
-    startTransition(() => {
-      void fetchPage("", "newest", 0, false).then(() => {
-        setInitialFetchDone(true);
-      });
-    });
-  }, [fetchPage]);
 
   async function handleLoadMore() {
     setLoadingMore(true);
@@ -241,7 +232,7 @@ export function LibraryPage({ initialData, initialTotal }: LibraryPageProps) {
 
         {/* Card grid */}
         {entries.length === 0 ? (
-          !initialFetchDone ? (
+          isPending ? (
             <SkeletonGrid />
           ) : (
             <div className="flex flex-col items-center gap-3 py-24 text-center">

--- a/lib/library-query.ts
+++ b/lib/library-query.ts
@@ -11,6 +11,13 @@ import {
 
 const VIEW_BOOST = 0.4;
 const TRENDING_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+/** Cap how many rows we pull per source when merging pages. */
+const MAX_FETCH_LIMIT = 96;
+
+const CODE_TABLE = "library_code_entries";
+const WEBSITE_TABLE = "library_website_entries";
+const CODE_COLUMNS = "id, owner, repo, prompt, cached_at, views, title";
+const WEBSITE_COLUMNS = "slug, target_url, prompt, cached_at";
 
 type PromptRow = {
   id: number;
@@ -36,6 +43,11 @@ function searchWords(raw: string): string[] {
     .split(/\s+/u)
     .map((w) => w.trim())
     .filter(Boolean);
+}
+
+function previewPrompt(prompt: string | null | undefined): string {
+  if (!prompt) return "";
+  return prompt.length > 180 ? prompt.slice(0, 180) : prompt;
 }
 
 function applyCodeSort(
@@ -97,11 +109,7 @@ async function fetchCodeBrowse(
   fetchLimit: number
 ): Promise<{ rows: PromptRow[]; total: number }> {
   const { data, count, error } = await applyCodeSort(
-    supabase
-      .from("prompt_cache")
-      .select("id, owner, repo, prompt, cached_at, views, title", {
-        count: "exact",
-      }),
+    supabase.from(CODE_TABLE).select(CODE_COLUMNS, { count: "exact" }),
     sort,
     false
   ).range(0, fetchLimit - 1);
@@ -116,9 +124,7 @@ async function fetchWebsiteBrowse(
   fetchLimit: number
 ): Promise<{ rows: WebsiteRow[]; total: number }> {
   const { data, count, error } = await applyWebsiteSort(
-    supabase
-      .from("website_reverse_cache")
-      .select("slug, target_url, prompt, cached_at", { count: "exact" }),
+    supabase.from(WEBSITE_TABLE).select(WEBSITE_COLUMNS, { count: "exact" }),
     sort
   ).range(0, fetchLimit - 1);
 
@@ -138,10 +144,8 @@ async function fetchCodeSearch(
 
   const runQuery = (strategy?: FtsStrategy) => {
     let query = supabase
-      .from("prompt_cache")
-      .select("id, owner, repo, prompt, cached_at, views, title", {
-        count: "exact",
-      });
+      .from(CODE_TABLE)
+      .select(CODE_COLUMNS, { count: "exact" });
 
     if (words.length > 0 && strategy) {
       switch (strategy) {
@@ -158,9 +162,10 @@ async function fetchCodeSearch(
           });
           break;
         case "ilike-and":
+          // Avoid ilike on prompt — full-text scan blows past anon's 3s timeout.
           for (const word of words) {
             query = query.or(
-              `owner.ilike.%${word}%,repo.ilike.%${word}%,prompt.ilike.%${word}%`
+              `owner.ilike.%${word}%,repo.ilike.%${word}%,title.ilike.%${word}%`
             );
           }
           break;
@@ -168,7 +173,7 @@ async function fetchCodeSearch(
           const clauses = words.flatMap((w) => [
             `owner.ilike.%${w}%`,
             `repo.ilike.%${w}%`,
-            `prompt.ilike.%${w}%`,
+            `title.ilike.%${w}%`,
           ]);
           query = query.or(clauses.join(","));
           break;
@@ -216,14 +221,13 @@ async function fetchWebsiteSearch(
 ): Promise<{ rows: WebsiteRow[]; total: number }> {
   const words = searchWords(search);
   let query = supabase
-    .from("website_reverse_cache")
-    .select("slug, target_url, prompt, cached_at", { count: "exact" });
+    .from(WEBSITE_TABLE)
+    .select(WEBSITE_COLUMNS, { count: "exact" });
 
   if (words.length > 0) {
+    // Metadata-only match — scanning prompt text times out under anon limits.
     for (const word of words) {
-      query = query.or(
-        `slug.ilike.%${word}%,target_url.ilike.%${word}%,prompt.ilike.%${word}%`
-      );
+      query = query.or(`slug.ilike.%${word}%,target_url.ilike.%${word}%`);
     }
   }
 
@@ -237,7 +241,6 @@ async function fetchWebsiteSearch(
 }
 
 function scoreWebsiteSearch(row: WebsiteRow, search: string): number {
-  const haystack = `${row.slug} ${row.target_url} ${row.prompt}`.toLowerCase();
   const words = searchWords(search);
   if (words.length === 0) return 0;
   let score = 0;
@@ -270,21 +273,31 @@ async function fetchCodeHybrid(
   if (ids.length === 0) return rows;
 
   const { data: titleRows } = await supabase
-    .from("prompt_cache")
-    .select("id, title")
+    .from(CODE_TABLE)
+    .select("id, title, prompt")
     .in("id", ids);
 
-  const titleById = new Map(
-    (titleRows ?? []).map((row) => [row.id as number, row.title as string | null])
+  const metaById = new Map(
+    (titleRows ?? []).map((row) => [
+      row.id as number,
+      {
+        title: row.title as string | null,
+        prompt: previewPrompt(row.prompt as string | null),
+      },
+    ])
   );
 
-  const boosted = rows.map((row) => ({
-    ...row,
-    title: titleById.get(row.id) ?? row.title ?? null,
-    relevance_score:
-      (row.relevance_score ?? 0) *
-      (1 + Math.log10((row.views ?? 0) + 1) * VIEW_BOOST),
-  }));
+  const boosted = rows.map((row) => {
+    const meta = metaById.get(row.id);
+    return {
+      ...row,
+      prompt: meta?.prompt ?? previewPrompt(row.prompt),
+      title: meta?.title ?? row.title ?? null,
+      relevance_score:
+        (row.relevance_score ?? 0) *
+        (1 + Math.log10((row.views ?? 0) + 1) * VIEW_BOOST),
+    };
+  });
 
   const maxScore = boosted.reduce(
     (max, row) => Math.max(max, row.relevance_score ?? 0),
@@ -353,13 +366,17 @@ function mergeSearch(
   return entries;
 }
 
+function mergeFetchLimit(page: number, limit: number): number {
+  return Math.min(MAX_FETCH_LIMIT, (page + 1) * limit);
+}
+
 export async function browseLibrary(opts: {
   supabase: SupabaseClient;
   sort: SortOption;
   page: number;
   limit: number;
 }): Promise<{ data: LibraryEntry[]; total: number }> {
-  const fetchLimit = (opts.page + 1) * opts.limit;
+  const fetchLimit = mergeFetchLimit(opts.page, opts.limit);
   const [code, website] = await Promise.all([
     fetchCodeBrowse(opts.supabase, opts.sort, fetchLimit),
     fetchWebsiteBrowse(opts.supabase, opts.sort, fetchLimit),
@@ -384,7 +401,7 @@ export async function searchLibrary(opts: {
   total: number;
   strategy: string;
 }> {
-  const fetchLimit = (opts.page + 1) * opts.limit;
+  const fetchLimit = mergeFetchLimit(opts.page, opts.limit);
 
   if (opts.useHybrid) {
     try {

--- a/supabase/migrations/20260717120000_library_browse_indexes_and_views.sql
+++ b/supabase/migrations/20260717120000_library_browse_indexes_and_views.sql
@@ -1,0 +1,35 @@
+-- Fast sort paths for /library (anon statement_timeout is 3s)
+CREATE INDEX IF NOT EXISTS prompt_cache_cached_at_idx
+  ON public.prompt_cache (cached_at DESC);
+
+CREATE INDEX IF NOT EXISTS prompt_cache_trending_idx
+  ON public.prompt_cache (views DESC, cached_at DESC);
+
+CREATE INDEX IF NOT EXISTS website_reverse_cache_cached_at_idx
+  ON public.website_reverse_cache (cached_at DESC);
+
+-- Lightweight projections so library cards never pull full prompt / design_md
+CREATE OR REPLACE VIEW public.library_code_entries
+WITH (security_invoker = true) AS
+SELECT
+  id,
+  owner,
+  repo,
+  left(prompt, 180) AS prompt,
+  cached_at,
+  views,
+  title,
+  search_vector
+FROM public.prompt_cache;
+
+CREATE OR REPLACE VIEW public.library_website_entries
+WITH (security_invoker = true) AS
+SELECT
+  slug,
+  target_url,
+  left(prompt, 180) AS prompt,
+  cached_at
+FROM public.website_reverse_cache;
+
+GRANT SELECT ON public.library_code_entries TO anon, authenticated;
+GRANT SELECT ON public.library_website_entries TO anon, authenticated;


### PR DESCRIPTION
## Summary
- Fix Postgres statement timeouts on `/library` by adding browse indexes and lightweight prompt-preview views
- Cache the library page (60s revalidate) and stop the remount double-fetch
- Avoid full-prompt `ilike` scans that blow past the anon 3s timeout

## Test plan
- [x] Preview deployment Ready on Vercel
- [ ] Open `/library` on production after merge — should return 200 quickly
- [ ] Confirm cards show prompt previews and load-more still works
- [ ] Confirm search still returns results
