### PR TITLE
Add website reverse timing logs for latency debugging.

### DIFF
--- a/app/api/reverse-website/route.ts
+++ b/app/api/reverse-website/route.ts
@@ -167,6 +167,7 @@ async function runWebsiteReverse(opts: {
     }
   }
 
+  const requestStartedAt = Date.now();
   const llm = resolveLlmTarget();
   if ("error" in llm) {
     return { ok: false, error: llm.error, status: 500 };
@@ -174,16 +175,24 @@ async function runWebsiteReverse(opts: {
 
   onStatus?.("Visiting site");
   let evidence: WebsiteEvidence;
+  const evidenceStartedAt = Date.now();
   try {
     evidence = await gatherWebsiteEvidence(targetUrl);
     onStatus?.(evidenceStatusMessage(evidence.source));
+    console.log(
+      `[reverse-website] evidence source=${evidence.source} elapsed=${Date.now() - evidenceStartedAt}ms`
+    );
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
+    console.log(
+      `[reverse-website] evidence FAILED after ${Date.now() - evidenceStartedAt}ms: ${msg}`
+    );
     return { ok: false, error: msg, status: 502 };
   }
 
   onStatus?.("Understanding design");
   onStatus?.("Writing design.md");
+  const designStartedAt = Date.now();
   const designResult = await callQuickLlm(
     llm,
     buildWebsiteDesignSystemPrompt(),
@@ -193,11 +202,13 @@ async function runWebsiteReverse(opts: {
     }),
     12_000
   );
+  console.log(`[reverse-website] design.md elapsed=${Date.now() - designStartedAt}ms`);
   if (!designResult.ok) {
     return { ok: false, error: designResult.error, status: designResult.status };
   }
 
   onStatus?.("Reverse engineering prompt");
+  const promptStartedAt = Date.now();
   const promptResult = await callQuickLlm(
     llm,
     WEBSITE_REVERSE_SYSTEM_PROMPT,
@@ -208,11 +219,13 @@ async function runWebsiteReverse(opts: {
     }),
     4096
   );
+  console.log(`[reverse-website] prompt elapsed=${Date.now() - promptStartedAt}ms`);
   if (!promptResult.ok) {
     return { ok: false, error: promptResult.error, status: promptResult.status };
   }
 
   const finalPrompt = appendDesignSystemLink(promptResult.text, slug);
+  console.log(`[reverse-website] TOTAL elapsed=${Date.now() - requestStartedAt}ms`);
 
   try {
     await writeWebsiteReverse({

--- a/lib/firecrawl-client.ts
+++ b/lib/firecrawl-client.ts
@@ -22,6 +22,7 @@ export async function scrapeWebsite(url: string): Promise<FirecrawlScrapeResult>
     );
   }
 
+  const startedAt = Date.now();
   let res: Response;
   try {
     res = await fetch(FIRECRAWL_SCRAPE_URL, {
@@ -36,8 +37,10 @@ export async function scrapeWebsite(url: string): Promise<FirecrawlScrapeResult>
         onlyMainContent: true,
       }),
     });
+    console.log(`[firecrawl] scrape ${url} status=${res.status} elapsed=${Date.now() - startedAt}ms`);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
+    console.log(`[firecrawl] scrape ${url} FAILED after ${Date.now() - startedAt}ms: ${msg}`);
     throw new Error(`Firecrawl request failed: ${msg}`);
   }
 

--- a/lib/quick-llm.ts
+++ b/lib/quick-llm.ts
@@ -5,6 +5,7 @@ import {
   getAzureOpenAiBaseUrl,
   getAzureQuickModel,
   getAzureQuickReasoningEffort,
+  resolveAzureDeploymentName,
   type AzureOpenAiReasoningEffort,
 } from "@/lib/azure-openai";
 
@@ -270,6 +271,10 @@ export async function callQuickLlm(
           max_tokens: maxCompletionTokens,
         };
 
+  const deploymentLabel =
+    llm.provider === "azure" ? resolveAzureDeploymentName(llm.model) : llm.model;
+  const startedAt = Date.now();
+
   let res: Response;
   try {
     res = await fetch(llm.url, {
@@ -280,6 +285,9 @@ export async function callQuickLlm(
   } catch (e) {
     const label = providerDisplayName(llm.provider);
     const message = e instanceof Error ? e.message : `${label} request failed`;
+    console.log(
+      `[quick-llm] ${llm.provider}/${deploymentLabel} FAILED after ${Date.now() - startedAt}ms: ${message}`
+    );
     return { ok: false, error: `Generation failed: ${message}`, status: 500 };
   }
 
@@ -288,12 +296,24 @@ export async function callQuickLlm(
     data = await res.json();
   } catch {
     const label = providerDisplayName(llm.provider);
+    console.log(
+      `[quick-llm] ${llm.provider}/${deploymentLabel} invalid JSON after ${Date.now() - startedAt}ms`
+    );
     return {
       ok: false,
       error: `${label} returned invalid JSON.`,
       status: 502,
     };
   }
+
+  const elapsedMs = Date.now() - startedAt;
+  const usage =
+    data && typeof data === "object" && "usage" in data
+      ? (data as { usage?: Record<string, unknown> }).usage
+      : undefined;
+  console.log(
+    `[quick-llm] ${llm.provider}/${deploymentLabel} reasoning=${llm.reasoningEffort ?? "n/a"} status=${res.status} elapsed=${elapsedMs}ms usage=${JSON.stringify(usage ?? {})}`
+  );
 
   if (!res.ok) {
     const label = providerDisplayName(llm.provider);


### PR DESCRIPTION
Logs Firecrawl scrape duration, LLM deployment/reasoning usage, and per-phase reverse-website timings to support gradual performance work.