### PR TITLE
Fix design links using Vercel deployment host

### DIFF
--- a/lib/site-url.ts
+++ b/lib/site-url.ts
@@ -3,6 +3,9 @@ import { parseWebsiteReverseHost } from "@/lib/parse-website-reverse-host";
 export function getSiteBaseUrl(): string {
   const fromEnv = process.env.NEXT_PUBLIC_SITE_URL?.trim();
   if (fromEnv) return fromEnv.replace(/\/$/, "");
+  // Stable production domain — never the per-deployment *.vercel.app hostname
+  const prod = process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim();
+  if (prod) return `https://${prod.replace(/^https?:\/\//, "").replace(/\/$/, "")}`;
   const vercel = process.env.VERCEL_URL?.trim();
   if (vercel) return `https://${vercel.replace(/\/$/, "")}`;
   return "http://localhost:3000";


### PR DESCRIPTION
## Summary
- Prefer \NEXT_PUBLIC_SITE_URL\ / \VERCEL_PROJECT_PRODUCTION_URL\ over per-deployment \VERCEL_URL\
- Set \NEXT_PUBLIC_SITE_URL=https://gitreverse.com\ on Vercel production
- Re-healed cache rows that got rewritten to \*.vercel.app\ hosts

## Test plan
- [ ] Reverse/open pinterest — prompt ends with \https://gitreverse.com/designs/pinterest-com\
- [ ] No \*.vercel.app\ or \/api/website-design/\ in prompt suffix


Made with [Cursor](https://cursor.com)