### PR TITLE
Add Orynth ownership verification file

### DIFF
--- a/public/.well-known/ory-verify.txt
+++ b/public/.well-known/ory-verify.txt
@@ -1,0 +1,1 @@
+ory-verify=orynth-52cff9bf448444cfa83e545c9385b5ea


### PR DESCRIPTION
## Summary
- Adds `/.well-known/ory-verify.txt` for Orynth automatic domain ownership verification

## Test plan
- [x] Vercel preview deployment READY
- [x] `GET /.well-known/ory-verify.txt` returns `ory-verify=orynth-52cff9bf448444cfa83e545c9385b5ea`
- [ ] After merge, confirm file is live on production (`https://gitreverse.com/.well-known/ory-verify.txt`)
- [ ] Click Verify ownership in Orynth
